### PR TITLE
Apply creational design pattern to settings.py

### DIFF
--- a/covasim/settings.py
+++ b/covasim/settings.py
@@ -38,12 +38,6 @@ class IBuilder():
             sim.run()
             assert sim.people.rel_trans.dtype == np.float64
         '''
-        import importlib
-        import covasim as cv
-        importlib.reload(cv.defaults)
-        importlib.reload(cv.utils)
-        importlib.reload(cv)
-        return
     
     @staticmethod
     @abstractmethod
@@ -62,6 +56,11 @@ class Builder(IBuilder):
         return self
     
     def build_reload_numba(self):
+        import importlib
+        import covasim as cv
+        importlib.reload(cv.defaults)
+        importlib.reload(cv.utils)
+        importlib.reload(cv)
         self.product.build_reload_numba()
         return self
 

--- a/covasim/settings.py
+++ b/covasim/settings.py
@@ -15,6 +15,78 @@ import sciris as sc
 
 __all__ = ['options']
 
+class IBuilder():
+    "The Builder Interface"
+
+    @staticmethod
+    @abstractmethod
+    def build_reloading_inprogress():
+        "Reloading Covasim so changes take effect"
+
+    @staticmethod
+    @abstractmethod
+    def build_reload_numba():
+        '''
+        Apply changes to Numba functions -- reloading modules is necessary for
+        changes to propagate. Not necessary to call directly if cv.options.set() is used.
+
+        **Example**::
+
+            import covasim as cv
+            cv.options.set(precision=64)
+            sim = cv.Sim()
+            sim.run()
+            assert sim.people.rel_trans.dtype == np.float64
+        '''
+        import importlib
+        import covasim as cv
+        importlib.reload(cv.defaults)
+        importlib.reload(cv.utils)
+        importlib.reload(cv)
+        return
+    
+    @staticmethod
+    @abstractmethod
+    def build_reload_complete():
+        "Reload complete"
+    
+
+class Builder(IBuilder):
+    "The Concrete Builder."
+
+    def __init__(self):
+        self.product = Product()
+    
+    def build_reloading_inprogress(self):
+        self.product.parts.append('Reloading Covasim so changes take effect...')
+        return self
+    
+    def build_reload_numba(self):
+        self.product.build_reload_numba()
+        return self
+
+    def build_reload_complete(self):
+        self.product.parts.append('Reload complete. Note: for some options to take effect, you may also need to delete Covasims __pycache__ folder.')
+        return self
+
+class Product():
+    "The Product"
+
+    def __init__(self):
+        self.parts = []
+
+class Director:
+    "The Director, building a complex representation."
+
+    @staticmethod
+    def construct():
+        "Constructs and returns the final product"
+        return Builder()\
+            .build_reloading_inprogress()\
+            .build_reload_numba()\
+            .build_reload_complete()
+
+PRODUCT = Director.construct()
 
 def set_default_options():
     '''
@@ -213,26 +285,7 @@ def handle_show(do_show):
 
 
 def reload_numba():
-    '''
-    Apply changes to Numba functions -- reloading modules is necessary for
-    changes to propagate. Not necessary to call directly if cv.options.set() is used.
-
-    **Example**::
-
-        import covasim as cv
-        cv.options.set(precision=64)
-        sim = cv.Sim()
-        sim.run()
-        assert sim.people.rel_trans.dtype == np.float64
-    '''
-    print('Reloading Covasim so changes take effect...')
-    import importlib
-    import covasim as cv
-    importlib.reload(cv.defaults)
-    importlib.reload(cv.utils)
-    importlib.reload(cv)
-    print("Reload complete. Note: for some options to take effect, you may also need to delete Covasim's __pycache__ folder.")
-    return
+    return PRODUCT.parts
 
 
 # Add these here to be more accessible to the user


### PR DESCRIPTION
## What is the current problem?
Currently in the settings.py file, there are complex objects that can be simplified. More importantly,  objects currently cannot be created in different representations. `reload_numba()` displays this issue. This PR will solve this so it can separate the construction of a complex object from its representation. This will allow for the same construction process to create different representations.

## What is the solution?
This problem can be solved by applying the builder design pattern, which is a creational design pattern. This PR will solve this issue by breaking up the `reload_numba()` into multiple objects: `build_reloading_inprogress`, `build_reload_numba`, and `build_reload_complete`. This will be done by using the builder interface, the builder, the product, and the director. The builder interface is just an interface class that the builder would use. The builder therefore uses the builder interface and builds the concrete product. The product is what is being built. Lastly, the director is used to create custom products using the `construct()` method. The `construct()` method in the Director class puts together the final product. Since a builder is being used, this would allow for these objects to be used in different representation if needed.

Note: This change is for a school lab project.